### PR TITLE
Add CTRL-A and CTRL-E support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The local echo controller tries to replicate most of the bash-like user experien
 - _Arrow navigation_: Use `left` and `right` arrows to navigate in your input
 - _Word-boundary navigation_: Use `alt+left` and `alt+right` to jump between words
 - _Word-boundary deletion_: Use `alt+backspace` to delete a word
+- _Start/End of line_: Use Ctrl-A and Ctrl-E to move to start / end of line
 - _Multi-line continuation_: Break command to multiple lines if they contain incomplete quotation marks, boolean operators (`&&` or `||`), pipe operator (`|`), or new-line escape sequence (`\`).
 - _Full-navigation on multi-line command_: You are not limited only on the line you are editing, you can navigate and edit all of your lines.
 - _Local History_: Just like bash, access the commands you previously typed using the `up` and `down` arrows.

--- a/src/index.ts
+++ b/src/index.ts
@@ -675,6 +675,14 @@ export class LocalEchoAddon extends IoEventTarget implements ITerminalAddon {
           }
           break;
 
+        case "\x01": // CTRL+A
+          this.setCursor(0);
+          break;
+
+        case "\x05": // CTRL+E
+          this.setCursor(this.input.length);
+          break;
+
         case "\x03": // CTRL+C
           this.setCursor(this.input.length);
           this.terminal.write(


### PR DESCRIPTION
This PR adds support for the standard line editing characters CTRL-A and CTRL-E to move to the start of the line and end of the line respectively.

Readme was updated to note these two new control characters.